### PR TITLE
💥 add ci, enable clang-format, misc. fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: main-ci
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      # checkout v2, with recursive submodule update
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      # build the Docker image we use to run the tests
+      - name: test.sh
+        run: TOX_PARALLEL_NO_SPINNER=1 ./test.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:focal
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get -y install \
+    python3-pip \
+    software-properties-common
+
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get update && apt-get -y install \
+    clang-format \
+    python2.7 \
+    python3.6 \
+    python3.7 \
+    python3.8
+
+# get user id from build arg, so we can have read/write access to directories
+# mounted inside the container. only the UID is necessary, UNAME just for
+# cosmetics
+ARG UID=1010
+ARG UNAME=builder
+
+RUN useradd --uid $UID --create-home --user-group ${UNAME} && \
+    echo "${UNAME}:${UNAME}" | chpasswd && adduser ${UNAME} sudo
+
+USER ${UNAME}
+
+# Install Conda
+# Copied from continuumio/miniconda3
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+ENV PATH /home/${UNAME}/.local/bin:$PATH
+
+# Install these in the base conda env
+RUN pip3 install --user \
+    tox==3.15.0

--- a/mock_test-header.cpp
+++ b/mock_test-header.cpp
@@ -1,0 +1,18 @@
+//! @file
+//! @copyright Copyright 2020. All Rights Reserved
+//!
+//! @details
+
+#include "CppUTest/TestHarness.h"
+#include "CppUTestExt/MockSupport.h"
+
+extern "C" {
+#include "test-header.h"
+}
+
+char *yolo(int somarg) {
+  return (char *)mock()
+      .actualCall(__func__)
+      .withParameter("somarg", somarg)
+      .returnPointerValueOrDefault(WRITEME);
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = [
+    "setuptools >= 40.0.4",
+    # since this isn't built into a wheel yet the below isn't needed
+    # "wheel >= 0.29.0",
+]
+build-backend = 'setuptools.build_meta'
+
+[tool.pylint.'MESSAGES CONTROL']
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+# Disable these checks; prefer black formatting
+disable=""",
+      bad-continuation,
+      fixme,
+      line-too-long,
+      useless-object-inheritance,
+"""
+# [tool.pylint.'BASIC']
+# # Good variable names which should always be accepted, separated by a comma.
+# good-names=""",
+#       polly-merge,
+# """

--- a/test-header.h
+++ b/test-header.h
@@ -1,0 +1,3 @@
+char *yolo(
+    int somarg
+);

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Simple test script to run the tests in docker
+
+# Error on any non-zero command, and print the commands as they're run
+set -ex
+
+# Make sure we have the docker utility
+if ! command -v docker; then
+    echo "🐋 Please install docker first 🐋"
+    exit 1
+fi
+
+# Set the docker image name to default to repo basename
+DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAME:-$(basename -s .git "$(git remote --verbose | awk 'NR==1 { print tolower($2) }')")}
+
+# build the docker image
+DOCKER_BUILDKIT=1 docker build -t "$DOCKER_IMAGE_NAME" --build-arg "UID=$(id -u)" -f Dockerfile .
+
+# execute tox in the docker container. don't run in parallel.
+docker run -v "$(pwd)":/mnt/workspace \
+    -e TOX_PARALLEL_NO_SPINNER="$TOX_PARALLEL_NO_SPINNER" \
+    -t "$DOCKER_IMAGE_NAME" \
+    bash -c "cd /mnt/workspace && tox --parallel auto"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,57 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+#
+
+[tox]
+isolated_build = True
+envlist =
+    py{27,36,37,38}
+    black
+    isort
+
+[testenv]
+deps =
+    py27: pylint==1.9.5
+    py{36,37,38}: pylint==2.5.0
+commands =
+    pylint cpputest_mockify.py
+
+[testenv:py27]
+whitelist_externals =
+    /bin/bash
+    /bin/echo
+    /usr/bin/bash
+    /usr/bin/diff
+    /usr/bin/echo
+deps =
+    py27: pylint==1.9.5
+basepython=python2.7
+commands =
+    pylint --disable="bad-continuation,fixme,line-too-long" cpputest_mockify.py
+
+    # run the tool on a test corpus and verify the output exactly matches
+    bash -c "echo 'n' | {envpython} cpputest_mockify.py test-header.h {envdir}/"
+    # test overwriting. normally use a here-doc (<<< "y") but not working in tox
+    bash -c "echo 'y' | {envpython} cpputest_mockify.py test-header.h {envdir}/"
+    diff mock_test-header.cpp {envdir}/mock_test-header.cpp
+
+# black formatting required
+[testenv:black]
+deps=
+    black==19.10b0
+basepython=python3
+commands=
+    black --check --verbose .
+
+# verify imports are sorted properly
+[testenv:isort]
+whitelist_externals =
+    /usr/bin/bash
+    /bin/bash
+deps=
+    isort[pyproject]==4.3.9
+basepython=python3
+commands=
+    bash -c "cd {toxinidir} && isort -c"


### PR DESCRIPTION
Add gi (github actions) via Dockerfile + tox, testing on
py27,py36,py37,py38.

Enable clang-format (at least, clang-format-10 on my machine will hang
with no args waiting for stdin, so pass `--help` to skip it).

Fix some pylint/import errors and py3 compatibility errors.

Fixes #1.
Fixes #2.